### PR TITLE
Added unit tests for StackPointerBackpropagator

### DIFF
--- a/src/Decompiler/Analysis/StackPointerBackpropagator.cs
+++ b/src/Decompiler/Analysis/StackPointerBackpropagator.cs
@@ -84,7 +84,7 @@ namespace Reko.Analysis
         private bool IsTrashed(Identifier sp)
         {
             var definition = ssa.Identifiers[sp].DefStatement;
-            switch (definition.Instruction)
+            switch (definition?.Instruction)
             {
             case CallInstruction _:
             case PhiAssignment _:

--- a/src/UnitTests/Analysis/StackPointerBackpropagatorTests.cs
+++ b/src/UnitTests/Analysis/StackPointerBackpropagatorTests.cs
@@ -1,0 +1,204 @@
+#region License
+/* 
+ * Copyright (C) 1999-2018 John Källén.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#endregion
+
+using NUnit.Framework;
+using Reko.Analysis;
+using Reko.Core;
+using Reko.UnitTests.Mocks;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+
+namespace Reko.UnitTests.Analysis
+{
+    [TestFixture]
+    public class StackPointerBackpropagatorTests
+    {
+        private Program program;
+
+        [SetUp]
+        public void Setup()
+        {
+            var arch = new FakeArchitecture();
+            var platform = new FakePlatform(null, arch);
+            this.program = new Program
+            {
+                Architecture = arch,
+                Platform  = platform,
+            };
+        }
+
+        private void AssertStringsEqual(string sExp, SsaState ssa)
+        {
+            var sw = new StringWriter();
+            ssa.Procedure.Write(false, sw);
+            var sActual = sw.ToString();
+            if (sExp != sActual)
+            {
+                Debug.Print("{0}", sActual);
+                Assert.AreEqual(sExp, sActual);
+            }
+        }
+
+        private SsaState RunTest(ProcedureBuilder m)
+        {
+            var proc = m.Procedure;
+            var scc = new HashSet<Procedure> { proc };
+            var sst = new SsaTransform(program, m.Procedure, scc, null, null);
+            sst.Transform();
+            sst.AddUsesToExitBlock();
+            var ssa = sst.SsaState;
+            var spbp = new StackPointerBackpropagator(ssa);
+            spbp.BackpropagateStackPointer();
+            return ssa;
+        }
+
+        [Test]
+        public void Spbp_LinearProcedure()
+        {
+            var m = new ProcedureBuilder(program.Architecture);
+
+            var fp = m.Frame.FramePointer;
+            var sp = m.Frame.EnsureRegister(m.Architecture.StackRegister);
+            var r1 = m.Reg32("r1");
+            var r2 = m.Reg32("r2");
+            m.Assign(sp, fp);
+            m.Assign(sp, m.ISub(sp, m.Int32(4)));
+            m.MStore(sp, r1);
+            m.Call(r2, 4);      // Indirect call = hell node
+            m.Assign(r1, m.Mem32(sp));
+            m.Assign(sp, m.IAdd(sp, m.Int32(4)));
+            m.Return();
+
+            SsaState ssa = RunTest(m);
+
+            var sExp =
+            #region Expected
+@"// ProcedureBuilder
+// Return size: 0
+define ProcedureBuilder
+ProcedureBuilder_entry:
+	def fp
+	def r1
+	def r2
+	// succ:  l1
+l1:
+	r63_2 = fp
+	r63_3 = r63_2 - 4
+	Mem5[r63_3:word32] = r1
+	call r2 (retsize: 4;)
+		uses: r1:r1,r2:r2,r63:r63_3
+		defs: r1:r1_8,r2:r2_9
+	r63_7 = fp - 4
+	r1_10 = Mem5[r63_7:word32]
+	r63_11 = r63_7 + 4
+	return
+	// succ:  ProcedureBuilder_exit
+ProcedureBuilder_exit:
+	use r1_10
+	use r2_9
+	use r63_11
+";
+            #endregion
+            AssertStringsEqual(sExp, ssa);
+        }
+
+        [Test(Description = "This mirrors real world code which has more than one epilog")]
+        [Ignore("It would be nice if this passed.")]
+        public void Spbp_TwoExits()
+        {
+            var m = new ProcedureBuilder(program.Architecture);
+
+            var fp = m.Frame.FramePointer;
+            var sp = m.Frame.EnsureRegister(m.Architecture.StackRegister);
+            var r1 = m.Reg32("r1");
+            var r2 = m.Reg32("r2");
+            var r3 = m.Reg32("r3");
+            m.Assign(sp, fp);
+            m.Assign(sp, m.ISub(sp, m.Int32(4)));
+            m.MStore(sp, r1);
+            m.BranchIf(m.Eq0(r3), "m_eq0");
+
+            m.Label("m_ne0");
+            m.Call(m.Mem32(m.IAdd(r2, 4)), 4);      // Indirect call = hell node
+            m.Assign(r1, m.Mem32(sp));
+            m.Assign(sp, m.IAdd(sp, m.Int32(4)));
+            m.Return();
+
+            m.Label("m_eq0");
+            m.Call(m.Mem32(m.IAdd(r2, 8)), 4);      // Indirect call = hell node
+            m.Assign(r1, m.Mem32(sp));
+            m.Assign(sp, m.IAdd(sp, m.Int32(4)));
+            m.Return();
+
+            SsaState ssa = RunTest(m);
+
+            var sExp =
+            #region Expected
+@"// ProcedureBuilder
+// Return size: 0
+define ProcedureBuilder
+ProcedureBuilder_entry:
+	def fp
+	def r1
+	def r3
+	def r2
+	// succ:  l1
+l1:
+	r63_2 = fp
+	r63_3 = r63_2 - 4
+	Mem5[r63_3:word32] = r1
+	branch r3 == 0x00000000 m_eq0
+	goto m_ne0
+	// succ:  m_ne0 m_eq0
+m_eq0:
+	call Mem5[r2 + 0x00000008:word32] (retsize: 4;)
+		uses: r1:r1,r2:r2,r3:r3,r63:r63_3
+		defs: r1:r1_9,r2:r2_10,r3:r3_11,r63:r63_8
+	r63_14 = fp - 4
+	r1_12 = Mem5[r63_8:word32]
+	r63_13 = r63_8 + 4
+	return
+	// succ:  ProcedureBuilder_exit
+m_ne0:
+	call Mem5[r2 + 0x00000004:word32] (retsize: 4;)
+		uses: r1:r1,r2:r2,r3:r3,r63:r63_3
+		defs: r1:r1_15,r2:r2_16,r3:r3_17
+	r63_14 = fp - 4
+	r1_18 = Mem5[r63_14:word32]
+	r63_19 = r63_14 + 4
+	return
+	// succ:  ProcedureBuilder_exit
+ProcedureBuilder_exit:
+	r63_23 = PHI(r63_19, r63_13)
+	r3_22 = PHI(r3_17, r3_11)
+	r2_21 = PHI(r2_16, r2_10)
+	r1_20 = PHI(r1_18, r1_12)
+	use r1_20
+	use r2_21
+	use r3_22
+	use r63_23
+";
+            #endregion
+            AssertStringsEqual(sExp, ssa);
+        }
+
+    }
+}

--- a/src/UnitTests/Analysis/StackPointerBackpropagatorTests.cs
+++ b/src/UnitTests/Analysis/StackPointerBackpropagatorTests.cs
@@ -135,60 +135,91 @@ Spbp_LinearProcedure_exit:
         }
 
         [Test(Description = "This mirrors real world code which has more than one epilog")]
-        [Ignore("It would be nice if this passed.")]
+        [Ignore("It would be nice if this passed. I'm leaving the code as is, but it will need to be fixed up")]
         public void Spbp_TwoExits()
         {
             var m = new SsaProcedureBuilder(nameof(Spbp_TwoExits));
 
-            var fp = m.Frame.FramePointer;
-            var sp = m.Frame.EnsureRegister(m.Architecture.StackRegister);
+            var fp = m.Ssa.Identifiers.Add(m.Frame.FramePointer, null, null, false).Identifier;
+            var r63_1 = m.Reg("r63_1", m.Architecture.StackRegister);
+            var r63_2 = m.Reg("r63_2", m.Architecture.StackRegister);
+            var r63_3 = m.Reg("r63_3", m.Architecture.StackRegister);
+            var r63_4 = m.Reg("r63_4", m.Architecture.StackRegister);
+            var r63_5 = m.Reg("r63_5", m.Architecture.StackRegister);
+            var r63_6 = m.Reg("r63_6", m.Architecture.StackRegister);
+            var r63_7 = m.Reg("r63_7", m.Architecture.StackRegister);
             var r1 = m.Reg32("r1");
             var r2 = m.Reg32("r2");
             var r3 = m.Reg32("r3");
-            m.Assign(sp, fp);
-            m.Assign(sp, m.ISub(sp, m.Int32(4)));
-            m.MStore(sp, r1);
+            var r1_1 = m.Reg("r1_1", (RegisterStorage) r1.Storage);
+            var r1_2 = m.Reg("r1_2", (RegisterStorage) r1.Storage);
+            var r1_3 = m.Reg("r1_3", (RegisterStorage) r1.Storage);
+            var r1_4 = m.Reg("r1_4", (RegisterStorage) r1.Storage);
+            var r1_5 = m.Reg("r1_5", (RegisterStorage) r1.Storage);
+            var r2_1 = m.Reg("r2_1", (RegisterStorage) r2.Storage);
+            var r2_2 = m.Reg("r2_2", (RegisterStorage) r2.Storage);
+            var r2_3 = m.Reg("r2_3", (RegisterStorage) r2.Storage);
+            var r3_1 = m.Reg("r3_1", (RegisterStorage) r3.Storage);
+            var r3_2 = m.Reg("r3_2", (RegisterStorage) r3.Storage);
+            var r3_3 = m.Reg("r3_3", (RegisterStorage) r3.Storage);
+
+            m.AddDefToEntryBlock(fp);
+            m.AddDefToEntryBlock(r1);
+            m.AddDefToEntryBlock(r2);
+            m.AddDefToEntryBlock(r3);
+
+            m.Assign(r63_1, fp);
+            m.Assign(r63_2, m.ISub(r63_1, m.Int32(4)));
+            m.MStore(r63_2, r1);
             m.BranchIf(m.Eq0(r3), "m_eq0");
 
             m.Label("m_ne0");
-            m.Call(m.Mem32(m.IAdd(r2, 4)), 4);      // Indirect call = hell node
-            m.Assign(r1, m.Mem32(sp));
-            m.Assign(sp, m.IAdd(sp, m.Int32(4)));
+            m.Call(m.Mem32(m.IAdd(r2, 4)), 4,      // Indirect call = hell node
+                new[] { r1, r2, r3, r63_2 },
+                new[] { r1_1, r2_1, r3_1, r63_3 });
+            m.Assign(r1_2, m.Mem32(r63_3));
+            m.Assign(r63_4, m.IAdd(r63_3, m.Int32(4)));
             m.Return();
 
             m.Label("m_eq0");
-            m.Call(m.Mem32(m.IAdd(r2, 8)), 4);      // Indirect call = hell node
-            m.Assign(r1, m.Mem32(sp));
-            m.Assign(sp, m.IAdd(sp, m.Int32(4)));
+            m.Call(m.Mem32(m.IAdd(r2, 8)), 4,      // Indirect call = hell node
+                new[] { r1, r2, r3, r63_2 },
+                new[] { r1_3, r2_2, r3_2, r63_5 });
+            m.Assign(r1_4, m.Mem32(r63_5));
+            m.Assign(r63_6, m.IAdd(r63_5, m.Int32(4)));
             m.Return();
 
-            m.AddUseToExitBlock(r1);
-            m.AddUseToExitBlock(r2);
-            m.AddUseToExitBlock(r3);
-            m.AddUseToExitBlock(sp);
+            m.Phi(r1_5, r1_2, r1_4);
+            m.Phi(r2_3, r2_1, r2_3);
+            m.Phi(r3_3, r3_1, r2_3);
+            m.Phi(r63_6, r63_3, r63_5);
+            m.AddUseToExitBlock(r1_5);
+            m.AddUseToExitBlock(r2_3);
+            m.AddUseToExitBlock(r3_3);
+            m.AddUseToExitBlock(r63_6);
 
             SsaState ssa = RunTest(m.Ssa);
 
             var sExp =
             #region Expected
-@"// ProcedureBuilder
+@"// Spbp_TwoExits
 // Return size: 0
-define ProcedureBuilder
-ProcedureBuilder_entry:
+define Spbp_TwoExits
+Spbp_TwoExits_entry:
 	def fp
 	def r1
-	def r3
 	def r2
+	def r3
 	// succ:  l1
 l1:
-	r63_2 = fp
-	r63_3 = r63_2 - 4
-	Mem5[r63_3:word32] = r1
+	r63_1 = fp
+	r63_2 = r63_1 - 4
+	Mem22[r63_2:word32] = r1
 	branch r3 == 0x00000000 m_eq0
 	goto m_ne0
 	// succ:  m_ne0 m_eq0
 m_eq0:
-	call Mem5[r2 + 0x00000008:word32] (retsize: 4;)
+	call Mem22[r2 + 0x00000008:word32] (retsize: 4;)
 		uses: r1:r1,r2:r2,r3:r3,r63:r63_3
 		defs: r1:r1_9,r2:r2_10,r3:r3_11,r63:r63_8
 	r63_14 = fp - 4
@@ -204,8 +235,8 @@ m_ne0:
 	r1_18 = Mem5[r63_14:word32]
 	r63_19 = r63_14 + 4
 	return
-	// succ:  ProcedureBuilder_exit
-ProcedureBuilder_exit:
+	// succ:  Spbp_TwoExits_exit
+Spbp_TwoExits_exit:
 	r63_23 = PHI(r63_19, r63_13)
 	r3_22 = PHI(r3_17, r3_11)
 	r2_21 = PHI(r2_16, r2_10)

--- a/src/UnitTests/Mocks/ProcedureBuilder.cs
+++ b/src/UnitTests/Mocks/ProcedureBuilder.cs
@@ -1,6 +1,6 @@
 #region License
 /* 
- * Copyright (C) 1999-2018 John Källén.
+ * Copyright (C) 1999-2018 John KÃ¤llÃ©n.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -223,7 +223,12 @@ namespace Reko.UnitTests.Mocks
             return Block.Statements.Last;
         }
 
-        public void AddUseToExitBlock(Identifier id)
+        public virtual void AddDefToEntryBlock(Identifier id)
+        {
+            Procedure.EntryBlock.Statements.Add(0, new DefInstruction(id));
+        }
+
+        public virtual void AddUseToExitBlock(Identifier id)
         {
             Procedure.ExitBlock.Statements.Add(0, new UseInstruction(id));
         }

--- a/src/UnitTests/Mocks/SsaProcedureBuilder.cs
+++ b/src/UnitTests/Mocks/SsaProcedureBuilder.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 /* 
  * Copyright (C) 1999-2018 Pavel Tomin.
  *
@@ -75,6 +75,14 @@ namespace Reko.UnitTests.Mocks
             return sid.Identifier;
         }
 
+        public Identifier Temp(string name, TemporaryStorage stg)
+        { 
+            var id = new Identifier(stg.Name, stg.DataType, stg);
+            var sid = new SsaIdentifier(id, id, null, null, false);
+            Ssa.Identifiers.Add(id, sid);
+            return sid.Identifier;
+        }
+
         public Identifier Reg32(string name)
         {
             return Reg(name, PrimitiveType.Word32);
@@ -121,6 +129,14 @@ namespace Reko.UnitTests.Mocks
                     {
                         store.Dst = new MemoryAccess(memId, ea, dt);
                     }
+                }
+                break;
+            case CallInstruction call:
+                foreach (var def in call.Definitions)
+                {
+                    var id = (Identifier) def.Expression;
+                    Ssa.Identifiers[id].DefStatement = stm;
+                    Ssa.Identifiers[id].DefExpression = call.Callee;
                 }
                 break;
             }

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -139,6 +139,7 @@
   <ItemGroup>
     <Compile Include="Analysis\ProcedureFlowTests.cs" />
     <Compile Include="Analysis\SsaMutatorTests.cs" />
+    <Compile Include="Analysis\StackPointerBackpropagatorTests.cs" />
     <Compile Include="Arch\Alpha\AlphaDisassemblerTests.cs" />
     <Compile Include="Arch\Alpha\AlphaRewriterTests.cs" />
     <Compile Include="Arch\Arm\A64RewriterTests.cs" />


### PR DESCRIPTION
This adds two unit tests. The first one has a linear exit, which is the majority case. The second one illustrates the less common but not unusual case, where the compiler generates two exits for a procedure. It would be cool if we could get that to work.